### PR TITLE
URLを入力した時、自動でaタグが付くようにする

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,17 @@
-# frozen_string_literal: true
-
 module ApplicationHelper
+  require "uri"
+
+  def text_url_to_link(text)
+    URI.extract(text, ['http', 'https']).uniq.each do |url|
+      link_text = ""
+      link_text << "<a href=" << url << " target=\"_blank\">" << url << "</a>"
+
+      text.gsub!(url, link_text)
+    end
+
+    return text
+  end
+
   def full_title(page_title = '')
     base_title = 'Trilog'
     if page_title.blank?

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -60,7 +60,7 @@
               <%= note.subject %>
             </span>
             <div class="col-md-12 trip-note-content">
-              <%= note.content %>
+              <%= text_url_to_link(h(note.content)).html_safe %>
             </div>
           </div>
         <% end %>
@@ -98,7 +98,7 @@
                     <%= schedule.place %>
                   </p>
                   <p class="trip-schedule-memo">
-                    <%= schedule.memo %>
+                    <%= text_url_to_link(h(schedule.memo)).html_safe %>
                   </p>
                 </div>
               </div>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,7 +1,29 @@
-# frozen_string_literal: true
-
 require 'rails_helper'
 RSpec.describe ApplicationHelper, type: :helper do
+
+  describe '#text_url_to_link' do
+    it 'httpがついていればハイパーリンクで返すこと' do
+      text = "http://example.com"
+      expect(text_url_to_link(text)).to have_link
+    end
+
+    it 'httpsがついていればハイパーリンクで返すこと' do
+      text = "https://example.com"
+      expect(text_url_to_link(text)).to have_link
+    end
+
+    it 'httpがついていなければリンクにならないこと' do
+      text = "リンクなしテキスト"
+      expect(text_url_to_link(text)).not_to have_link
+    end
+
+    it 'httpのついたURLの後にテキストがあるときURLのみハイパーリンクで返すこと' do
+      text = "http://example.com テキスト"
+      expect(text_url_to_link(text)).to have_link 'http://example.com', href: 'http://example.com'
+      expect(text_url_to_link(text)).not_to have_link 'テキスト'
+    end
+  end
+
   describe '#full_title' do
     it 'nilだった時、basetitleのみ返すこと' do
       expect(full_title(nil)).to eq 'Trilog'


### PR DESCRIPTION
- [x] text_url_to_linkヘルパー作成

- [x] note.contentとschedule.memoの表示にtext_url_to_linkヘルパーを使用

- [x] text_url_to_linkのヘルパースペック